### PR TITLE
Fixed Caret RichTextField issues Related: #2945

### DIFF
--- a/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/ListForm.tsx
@@ -300,7 +300,7 @@ class ListForm extends React.Component<IListFormProps, IListFormState> {
         const data = this.state.fieldsSchema
           .reduce((newData, fld) => {
             if (fld.DefaultValue && fld.FieldType.indexOf("TaxonomyField") > -1) {
-              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#][0-9]+;#|^[0-9]+;#)", "g"), "")
+              newData[fld.InternalName] = fld.DefaultValue.replace(new RegExp("([#][0-9]+;#|^[0-9]+;#)", "g"), "");
             } else {
               newData[fld.InternalName] = fld.DefaultValue;
             }

--- a/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldRichTextEdit.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldRichTextEdit.tsx
@@ -23,9 +23,6 @@ const SPFieldRichTextEdit: React.SFC<ISPFormFieldProps> = (props) => {
     tinymce.init({});
     const { Name, RichTextMode } = props.fieldSchema;
     const value = props.value ? props.value : '';
-    if (tinymce.editors[`Editor-${Name}`] !== undefined) {
-        tinymce.editors[`Editor-${Name}`].setContent(value);
-    }
 
     const editorConfig = {
         "relative_urls": false, "convert_urls": false, "remove_script_host": false,
@@ -39,8 +36,8 @@ const SPFieldRichTextEdit: React.SFC<ISPFormFieldProps> = (props) => {
     return <Editor
         id={`Editor-${Name}`}
         init={editorConfig}
-        initialValue={props.value}
-        onChange={(event) => { props.valueChanged(event.target.getContent()); }}
+        value={value}
+        onEditorChange={props.valueChanged}
     />;
 };
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                              |
| New sample?     | no                              |
| Related issues? | fixes #2945 |

## What's in this Pull Request?

Fixes: 
1. React-list-form RichTextEditor caret is always placed on the first line
2. Pressing enter two times to get to a new line