### PR TITLE
Fix RichTextField not showing up when editing/republishing page

### DIFF
--- a/samples/react-list-form/npm-shrinkwrap.json
+++ b/samples/react-list-form/npm-shrinkwrap.json
@@ -4388,11 +4388,12 @@
       "dev": true
     },
     "@tinymce/tinymce-react": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-3.0.1.tgz",
-      "integrity": "sha512-19g2iHR6Bxp7FpnyA/71Aq5kzzM7D5adT87hL+QvcySH1NoqB2aTqBBdiF/0HoDVI/nXq7FbalmlIcVTen1WrQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-4.2.0.tgz",
+      "integrity": "sha512-Oyi/hDvARR29oqUwTgYXDnMV9E/c7C8V+iK+gUj9tndVXsfSJRYVOw3MTK9CCC9f7alN/S4CYaPpIaA3f4VZzw==",
       "requires": {
-        "prop-types": "^15.6.2"
+        "prop-types": "^15.6.2",
+        "tinymce": "^6.0.0 || ^5.5.1"
       }
     },
     "@types/adal-angular": {
@@ -19127,9 +19128,9 @@
       }
     },
     "tinymce": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.0.1.tgz",
-      "integrity": "sha512-bAKaEEtRd4BsXu6ySYflhO83Cg844LHrplcaWalbdeZjFXwkodtv3G6H1x2r6ThaOdyE4+otJtxPYlfzwyKDdw=="
+      "version": "5.10.5",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.5.tgz",
+      "integrity": "sha512-nFKtLhmoRtExBxUfv06JlkbQWux5D+d115vxSRAqUmccZdrtpFvOIYwZmikvulLdM9pfEpvO0B+RQ2qFV/+R7w=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/samples/react-list-form/package.json
+++ b/samples/react-list-form/package.json
@@ -19,7 +19,7 @@
     "@microsoft/sp-property-pane": "1.10.0",
     "@microsoft/sp-webpart-base": "1.10.0",
     "@pnp/spfx-controls-react": "^1.19.0",
-    "@tinymce/tinymce-react": "^3.0.1",
+    "@tinymce/tinymce-react": "^4.2.0",
     "@types/es6-promise": "0.0.33",
     "@types/react-dnd": "~2.0.34",
     "@types/webpack-env": "1.13.1",

--- a/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldRichTextEdit.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/formFields/SPFieldRichTextEdit.tsx
@@ -1,26 +1,26 @@
 import * as React from 'react';
 import { ISPFormFieldProps } from './SPFormField';
 
-import * as tinymce from 'tinymce';
-import 'tinymce/themes/silver';
-import 'tinymce/plugins/paste';
-import 'tinymce/plugins/link';
-import 'tinymce/plugins/image';
+import "tinymce/tinymce";
+import "tinymce/icons/default";
+import "tinymce/themes/silver";
+import "tinymce/plugins/paste";
+import "tinymce/plugins/link";
+import "tinymce/plugins/image";
 import 'tinymce/plugins/imagetools';
 import 'tinymce/plugins/advlist';
 import 'tinymce/plugins/print';
 import 'tinymce/plugins/autolink';
 import 'tinymce/plugins/lists';
-import 'tinymce/plugins/table';
+import "tinymce/plugins/table";
 import 'tinymce/plugins/preview';
 import 'tinymce/plugins/anchor';
 import 'tinymce/plugins/fullscreen';
 import 'tinymce/plugins/media';
-import 'tinymce/plugins/imagetools';
+import "tinymce/skins/content/default/content.min.css";
 import { Editor } from "@tinymce/tinymce-react";
 
 const SPFieldRichTextEdit: React.SFC<ISPFormFieldProps> = (props) => {
-    tinymce.init({});
     const { Name, RichTextMode } = props.fieldSchema;
     const value = props.value ? props.value : '';
 
@@ -34,7 +34,7 @@ const SPFieldRichTextEdit: React.SFC<ISPFormFieldProps> = (props) => {
         skin_url: "https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.0.1/skins/ui/oxide"
     };
     return <Editor
-        id={`Editor-${Name}`}
+        id={`Editor-${Name}-${Date.now().toString()}`}
         init={editorConfig}
         value={value}
         onEditorChange={props.valueChanged}


### PR DESCRIPTION
Fix RichTextField not showing up when editing/republishing page

Related: #2944

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New feature?    | no                                |
| New sample?     | no                               |
| Related issues? | fixes #2944 |

## What's in this Pull Request?

Fix RichTextField not showing up when editing/republishing page
- Tinymce does not reinitialize the editor if it finds it already on the page even though it's not rendered. Having a unique id at each render makes sure the editor gets initalized.

Bump tinymce version